### PR TITLE
Fix for Issue#12 : Grunt build is failing for develop branch

### DIFF
--- a/scripts/widgets/rti/rti-rec-script.js
+++ b/scripts/widgets/rti/rti-rec-script.js
@@ -343,10 +343,10 @@ var getMozuProducts = function(rtiProductList){
   _.each(rtiProductList, function(attrs) {
     var op = api.get('product', attrs.ProductId);
     op.then(function(data) {
-      data.data.rtiRank = attrs.rank;
-      data.data.slot = attrs.slot;
-      data.data.widgetId = attrs.widgetId;
-      data.data.href = attrs.url;      
+      data.data.rtiRank = attrs.rank||'';
+      data.data.slot = attrs.slot||'';
+      data.data.widgetId = attrs.widgetId||'';
+      data.data.href = attrs.url||'';      
       productList.push(data.data);
       if (--numReqs === 0) {
         _.defer(function() {


### PR DESCRIPTION
Grunt build is failing for develop branch, as it missing "," after jQuery lib. 

I've also noticed that its also importing unwanted jQuery-ui lib, it's a pretty heavy lib and not required for any of the operation in RTi widgets. 

So it will be better if we remove it because it's giving an unwanted error on page load.